### PR TITLE
Centralize sidebar responsive styles

### DIFF
--- a/public/assets/css/Transpoter/bookingHistory.css
+++ b/public/assets/css/Transpoter/bookingHistory.css
@@ -457,12 +457,7 @@
         gap: 1em;
       }
       
-      .sidebar {
-        width: 100%;
-        margin: 0 0 1em 0;
-        min-height: unset;
-        padding: 1em 0.5em;
-      }
+     
     }
 
     @media (max-width: 768px) {

--- a/public/assets/css/Transpoter/bookingnew.css
+++ b/public/assets/css/Transpoter/bookingnew.css
@@ -11,10 +11,11 @@ main {
   gap: 2em;
   max-width: 1300px;
   margin: 0 auto 100px auto;
-  padding: 6em 0 0 0;
+  padding: 6em 2em 0 2em;
 }
 
 .content {
+  flex: 1;
   min-width: 0;
 }
 
@@ -351,22 +352,6 @@ body.modal-open {
     margin-top: 20px;
   }
 
-  .sidebar {
-    width: 100%;
-    max-width: none;
-    height: auto;
-    margin: 0;
-  }
-
-  .sidebar ul {
-    display: flex;
-    gap: 10px;
-  }
-
-  .sidebar ul li {
-    margin: 0;
-  }
-}
 
 @media (max-width: 860px) {
   .filter-bar {

--- a/public/assets/css/Transpoter/common.css
+++ b/public/assets/css/Transpoter/common.css
@@ -79,6 +79,7 @@
   position: sticky;
   top: 100px;
   display: flex;
+  flex-shrink: 0;
   flex-direction: column;
   justify-content: space-between;
 }
@@ -147,6 +148,65 @@
   transform: scale(1.1);
 }
 
+/* Sidebar Responsive - Consistent Width & Height */
+@media (max-width: 1200px) {
+  .sidebar {
+    width: 240px;
+    max-width: 240px;
+  }
+}
+
+@media (max-width: 1080px) {
+  main {
+    flex-direction: column;
+  }
+  
+  .sidebar {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    max-height: none;
+    margin: 0 0 1em 0;
+    padding: 1em 0;
+    position: relative;
+    top: auto;
+  }
+  
+  .sidebar ul {
+    display: flex;
+    gap: 10px;
+    padding: 0.5em 0;
+    flex-wrap: wrap;
+  }
+  
+  .sidebar ul li {
+    flex: 1;
+    min-width: 80px;
+  }
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    margin: 0 0 1em 0;
+  }
+  
+  .sidebar ul {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .sidebar ul {
+    gap: 5px;
+  }
+  
+  .sidebar ul li a {
+    padding: 10px 12px;
+  }
+}
 
 /*Footer*/
 footer {

--- a/public/assets/css/Transpoter/dashboard.css
+++ b/public/assets/css/Transpoter/dashboard.css
@@ -410,12 +410,6 @@ main {
     gap: 1em;
     padding: 0.5em;
   }
-  .sidebar {
-    width: 100%;
-    margin: 0 0 1em 0;
-    min-height: unset;
-    padding: 1em 0.5em;
-  }
   .dashboard-content {
     margin-top: 0;
   }

--- a/public/assets/css/Transpoter/setting.css
+++ b/public/assets/css/Transpoter/setting.css
@@ -705,13 +705,6 @@ margin-bottom: 15px;
     gap: 1em;
   }
   
-  .sidebar {
-    width: 100%;
-    margin: 0 0 1em 0;
-    min-height: unset;
-    padding: 1em 0.5em;
-  }
-  
   .form-row,
   .form-row1 {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Consolidate responsive sidebar rules into common.css and remove duplicate per-page overrides. Added flex-shrink: 0 and breakpoint-specific sidebar rules (1200/1080/768/480px) to ensure consistent width, stacking, list layout and spacing. Adjusted bookingnew layout padding (added horizontal padding) and set .content { flex: 1 } to improve flex behavior. Removed redundant .sidebar blocks from bookingHistory, dashboard and setting, and cleaned up obsolete sidebar list styles in bookingnew.