### PR TITLE
Remove payment modal footer and closing divs

### DIFF
--- a/app/views/transpoter/payment_history.view.php
+++ b/app/views/transpoter/payment_history.view.php
@@ -30,20 +30,7 @@ if (!$isTransporter) {
 <!-- Payment Details Modal->
 <
             
-        </div>
-        <div class="modal-footer">
-            <button class="modal-btn download-btn" onclick="downloadInvoice()">
-                <i class="fas fa-download"></i> Download Invoice
-            </button>
-            <button class="modal-btn print-btn" onclick="printInvoice()">
-                <i class="fas fa-print"></i> Print
-            </button>
-            <button class="modal-btn close-btn" onclick="closePaymentModal()">
-                <i class="fas fa-times"></i> Close
-            </button>
-        </div>
-    </div>
-</div>
+        
 
 <!-- MAIN CONTENT -->
 <main>


### PR DESCRIPTION
Remove the Payment Details modal footer (Download, Print, Close buttons) and the extra closing divs from app/views/transpoter/payment_history.view.php to clean up malformed/duplicated modal markup introduced during previous edits.